### PR TITLE
Remove expensive api requests and refactoring

### DIFF
--- a/carrierwave-google-storage.gemspec
+++ b/carrierwave-google-storage.gemspec
@@ -22,6 +22,11 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'carrierwave', '~> 1.2.0'
   spec.add_dependency 'google-cloud-storage', '~> 1.9.0'
+  if RUBY_VERSION >= '2.2.2'
+    spec.add_dependency 'activemodel', '>= 3.2.0'
+  else
+    spec.add_dependency 'activemodel', '~> 4.2.7'
+  end
 
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'pry', '~> 0.10.3'

--- a/carrierwave-google-storage.gemspec
+++ b/carrierwave-google-storage.gemspec
@@ -1,35 +1,31 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'carrierwave/google/storage/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "carrierwave-google-storage"
+  spec.name          = 'carrierwave-google-storage'
   spec.version       = Carrierwave::Google::Storage::VERSION
-  spec.authors       = ["Jasdeep Singh"]
-  spec.email         = ["narang.jasdeep@gmail.com"]
+  spec.authors       = ['Jasdeep Singh']
+  spec.email         = ['narang.jasdeep@gmail.com']
 
-  spec.summary       = %q{Use gcloud for Google Cloud Storage support in CarrierWave.}
-  spec.description   = %q{A slimmer alternative to using Fog for Google Cloud Storage support in CarrierWave. Heavily inspired from carrierwave-aws}
-  spec.homepage      = "https://github.com/metaware/carrierwave-google-storage"
-  spec.license       = "MIT"
+  spec.summary       = %q(Use gcloud for Google Cloud Storage support in CarrierWave.)
+  spec.description   = %q(A slimmer alternative to using Fog for Google Cloud Storage support in CarrierWave. Heavily inspired from carrierwave-aws)
+  spec.homepage      = 'https://github.com/metaware/carrierwave-google-storage'
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_dependency 'google-cloud-storage', '~> 1.4.0'
-  spec.add_dependency 'carrierwave', '~> 1.0'
-  if RUBY_VERSION >= "2.2.2"
-    spec.add_dependency 'activemodel', ">= 3.2.0"
-  else
-    spec.add_dependency 'activemodel', "~> 4.2.7"
-  end
+  spec.add_dependency 'carrierwave', '~> 1.2.0'
+  spec.add_dependency 'google-cloud-storage', '~> 1.9.0'
 
-  spec.add_development_dependency "bundler", "~> 1.12"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "pry", "~> 0.10.3"
-  spec.add_development_dependency "uri-query_params", "~> 0.7.1"
+  spec.add_development_dependency 'bundler', '~> 1.12'
+  spec.add_development_dependency 'pry', '~> 0.10.3'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'uri-query_params', '~> 0.7.1'
 end

--- a/lib/carrierwave-google-storage.rb
+++ b/lib/carrierwave-google-storage.rb
@@ -6,18 +6,21 @@ require 'carrierwave/storage/gcloud_file'
 require 'carrierwave/storage/gcloud_options'
 require 'carrierwave/support/uri_filename'
 
-class CarrierWave::Uploader::Base
-  
-  ConfigurationError = Class.new(StandardError)
+module CarrierWave
+  module Uploader
+    class Base
 
-  add_config :gcloud_attributes
-  add_config :gcloud_bucket
-  add_config :gcloud_bucket_is_public
-  add_config :gcloud_credentials
-  add_config :gcloud_authenticated_url_expiration
+      ConfigurationError = Class.new(StandardError)
 
-  configure do |config|
-    config.storage_engines[:gcloud] = 'CarrierWave::Storage::Gcloud'
+      add_config :gcloud_attributes
+      add_config :gcloud_bucket
+      add_config :gcloud_bucket_is_public
+      add_config :gcloud_credentials
+      add_config :gcloud_authenticated_url_expiration
+
+      configure do |config|
+        config.storage_engines[:gcloud] = 'CarrierWave::Storage::Gcloud'
+      end
+    end
   end
-
 end

--- a/lib/carrierwave/google/storage/version.rb
+++ b/lib/carrierwave/google/storage/version.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 module Carrierwave
   module Google
     module Storage
-      VERSION = "0.7.0"
+      VERSION = '0.7.1'.freeze
     end
   end
 end

--- a/lib/carrierwave/storage/gcloud.rb
+++ b/lib/carrierwave/storage/gcloud.rb
@@ -45,7 +45,7 @@ module CarrierWave
       end
 
       def credentials
-        uploader.gcloud_credentials
+        uploader.gcloud_credentials || {}
       end
 
       private

--- a/lib/carrierwave/storage/gcloud.rb
+++ b/lib/carrierwave/storage/gcloud.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module CarrierWave
   module Storage
     class Gcloud < Abstract

--- a/lib/carrierwave/storage/gcloud.rb
+++ b/lib/carrierwave/storage/gcloud.rb
@@ -1,7 +1,6 @@
 module CarrierWave
   module Storage
     class Gcloud < Abstract
-    
       def self.connection_cache
         @connection_cache ||= {}
       end
@@ -9,27 +8,53 @@ module CarrierWave
       def self.clear_connection_cache!
         @connection_cache = {}
       end
-      
+
       def store!(file)
-        CarrierWave::Storage::GcloudFile.new(uploader, connection, uploader.store_path).tap do |gcloud_file|
+        GcloudFile.new(uploader, connection, uploader.store_path).tap do |gcloud_file|
           gcloud_file.store(file)
         end
       end
 
       def retrieve!(identifier)
-        CarrierWave::Storage::GcloudFile.new(uploader, connection, uploader.store_path(identifier)).retrieve
+        GcloudFile.new(uploader, connection, uploader.store_path(identifier))
+      end
+
+      def cache!(file)
+        GcloudFile.new(uploader, connection, uploader.cache_path).tap do |gcloud_file|
+          gcloud_file.store(file)
+        end
+      end
+
+      def retrieve_from_cache!(identifier)
+        GcloudFile.new(uploader, connection, uploader.cache_path(identifier))
+      end
+
+      def clean_cache!(_seconds)
+        raise 'use Object Lifecycle Management to clean the cache'
       end
 
       def connection
         @connection ||= begin
-          cert_path = Gem.loaded_specs['google-api-client'].full_gem_path+'/lib/cacerts.pem'
+          conn_cache = self.class.connection_cache
           ENV['SSL_CERT_FILE'] = cert_path
-          self.class.connection_cache[credentials] ||= ::Google::Cloud.new(credentials[:gcloud_project] || ENV["GCLOUD_PROJECT"], credentials[:gcloud_keyfile] || ENV["GCLOUD_KEYFILE"]).storage
+          conn_cache[credentials] ||= ::Google::Cloud.new(
+            credentials[:gcloud_project] || ENV['GCLOUD_PROJECT'],
+            credentials[:gcloud_keyfile] || ENV['GCLOUD_KEYFILE']
+          ).storage.bucket(uploader.gcloud_bucket)
         end
       end
 
       def credentials
         uploader.gcloud_credentials
+      end
+
+      private
+
+      def cert_path
+        @cert_path ||= begin
+          gem_path = Gem.loaded_specs['google-api-client'].full_gem_path
+          gem_path + '/lib/cacerts.pem'
+        end
       end
     end
   end

--- a/lib/carrierwave/storage/gcloud_file.rb
+++ b/lib/carrierwave/storage/gcloud_file.rb
@@ -1,39 +1,27 @@
+# frozen_string_literal: true
+
 module CarrierWave
   module Storage
     class GcloudFile
-    
+      GCLOUD_STORAGE_URL = 'https://storage.googleapis.com'
+
       attr_writer :file
-      attr_accessor :uploader, :connection, :path, 
-        :gcloud_options, :file_exists
+      attr_accessor :uploader, :connection, :path, :gcloud_options, :file_exists
 
       delegate :content_type, :size, to: :file
 
       def initialize(uploader, connection, path)
-        @uploader, @connection, @path = uploader, connection, path
+        @uploader   = uploader
+        @connection = connection
+        @path       = path
       end
 
       def file
-        by_verifying_existence { @file ||= bucket.file(path) }
-        @file
+        @file ||= bucket.file(path)
       end
-      alias_method :to_file, :file
-      
-      def retrieve
-        by_verifying_existence { @file ||= bucket.file(path) }
-        self
-      end
-      
-      def by_verifying_existence(&block)
-        begin
-          self.file_exists = true
-          yield
-        rescue Exception => exception
-          self.file_exists = false if (exception.class == ::Google::Cloud::Error::NotFoundError) && (exception.message == "Not Found")
-        end
-      end
+      alias to_file file
 
       def attributes
-        return unless file_exists
         {
           content_type: file.content_type,
           size: file.size,
@@ -41,15 +29,15 @@ module CarrierWave
           etag: file.etag
         }
       end
-      
+
       def delete
         deleted = file.delete
         self.file_exists = false if deleted
         deleted
       end
-      
+
       def exists?
-        self.file_exists
+        !file.nil?
       end
 
       def extension
@@ -62,14 +50,17 @@ module CarrierWave
       end
 
       def read
-        tmp_file = Tempfile.new(CarrierWave::Support::UriFilename.filename(file.name))
+        tmp_file = Tempfile.new(
+          CarrierWave::Support::UriFilename.filename(file.name)
+        )
         (file.download tmp_file.path, verify: :all).read
       end
 
       def store(new_file)
-        new_file_path = uploader.filename ?  uploader.filename : new_file.filename
-        # bucket.create_file new_file.path, "#{uploader.store_dir}/#{new_file_path}" 
-        bucket.create_file new_file.path, path, content_type: new_file.content_type
+        new_file_path = uploader.filename ? uploader.filename : new_file.filename
+        bucket.create_file(
+          new_file.path, path, content_type: new_file.content_type
+        )
         self
       end
 
@@ -78,28 +69,26 @@ module CarrierWave
       end
 
       def url(options = {})
-        return unless file_exists
         uploader.gcloud_bucket_is_public ? public_url : authenticated_url
       end
-      
+
       def authenticated_url(options = {})
-        file.signed_url
+        bucket.signed_url(path, options)
       end
 
       def public_url
         if uploader.asset_host
           "#{uploader.asset_host}/#{path}"
         else
-          file.public_url.to_s
+          "#{GCLOUD_STORAGE_URL}/#{uploader.gcloud_bucket}/#{@path}"
         end
       end
 
       private
 
       def bucket
-        bucket ||= connection.bucket(uploader.gcloud_bucket)
+        connection
       end
-
     end
   end
 end

--- a/lib/carrierwave/storage/gcloud_file.rb
+++ b/lib/carrierwave/storage/gcloud_file.rb
@@ -22,6 +22,7 @@ module CarrierWave
       alias to_file file
 
       def attributes
+        return unless exists?
         {
           content_type: file.content_type,
           size: file.size,
@@ -32,7 +33,7 @@ module CarrierWave
 
       def delete
         deleted = file.delete
-        self.file_exists = false if deleted
+        @file = nil if deleted
         deleted
       end
 

--- a/spec/features/storing_files_spec.rb
+++ b/spec/features/storing_files_spec.rb
@@ -5,8 +5,7 @@ describe 'Storing Files', type: :feature do
   let(:image)    { File.open('spec/fixtures/image.png', 'r') }
   let(:uploader) { FeatureUploader.new }
 
-  context "common cases" do
-
+  context 'common cases' do
     before(:each) do
       uploader.store!(image)
       uploader.retrieve_from_store!('image.png')
@@ -15,7 +14,6 @@ describe 'Storing Files', type: :feature do
     it 'uploads the file to the configured bucket' do
       expect(uploader.file.size).to eq(image.size)
       expect(uploader.file.read).to eq(image.read)
-
       image.close
       uploader.file.delete
     end
@@ -33,9 +31,9 @@ describe 'Storing Files', type: :feature do
 
     it 'retrieves the attributes for a stored file' do
       expect(uploader.file.attributes).to include(
-      :content_type,
-      :etag,
-      :updated_at
+        :content_type,
+        :etag,
+        :updated_at
       )
 
       expect(uploader.file.content_type).to eq('image/png')
@@ -63,35 +61,32 @@ describe 'Storing Files', type: :feature do
     end
   end
 
-  context "remote uploads" do
-
+  context 'remote uploads' do
     after(:each) do
       expect(uploader.url).to include(ENV['GCLOUD_BUCKET'])
       expect(uploader.url).to include(uploader.path)
       uploader.file.delete
     end
 
-    it "can upload from remote urls" do
-      uploader.download!("http://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png")
+    it 'can upload from remote urls' do
+      uploader.download!('http://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png')
       uploader.store!
       uploader.retrieve_from_store!(uploader.send(:original_filename))
     end
 
-    it "file names can be renamed when loading from remote urls" do
+    it 'file names can be renamed when loading from remote urls' do
       uploader.class_eval do
         def filename
-          "filename.png"
+          'filename.png'
         end
       end
-      uploader.download!("http://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png")
+      uploader.download!('http://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png')
       uploader.store!
       uploader.retrieve_from_store!(uploader.filename)
     end
-
   end
 
-  context "secured storage" do
-
+  context 'secured storage' do
     before(:each) do
       uploader.gcloud_bucket_is_public = false
       uploader.store!(image)
@@ -141,7 +136,5 @@ describe 'Storing Files', type: :feature do
       image.close
       uploader.file.delete
     end
-
   end
-
 end

--- a/spec/features/storing_files_spec.rb
+++ b/spec/features/storing_files_spec.rb
@@ -4,9 +4,9 @@ require 'uri/query_params'
 describe 'Storing Files', type: :feature do
   let(:image)    { File.open('spec/fixtures/image.png', 'r') }
   let(:uploader) { FeatureUploader.new }
-  
+
   context "common cases" do
-  
+
     before(:each) do
       uploader.store!(image)
       uploader.retrieve_from_store!('image.png')
@@ -19,13 +19,13 @@ describe 'Storing Files', type: :feature do
       image.close
       uploader.file.delete
     end
-    
-    it 'returns nil url if its not able to retrieve file from storage' do
+
+    it 'returns url even if its not available' do
       uploader.file.delete
       expect(uploader.file.exists?).to be_falsey
-      expect(uploader.file.url).to be_nil
+      expect(uploader.file.url).to be_present
     end
-    
+
     it 'is not able to retrieve attributes if file does not exists' do
       uploader.file.delete
       expect(uploader.file.attributes).to be_nil
@@ -62,21 +62,21 @@ describe 'Storing Files', type: :feature do
       uploader.file.delete
     end
   end
-  
+
   context "remote uploads" do
-    
+
     after(:each) do
       expect(uploader.url).to include(ENV['GCLOUD_BUCKET'])
       expect(uploader.url).to include(uploader.path)
       uploader.file.delete
     end
-    
+
     it "can upload from remote urls" do
       uploader.download!("http://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png")
       uploader.store!
       uploader.retrieve_from_store!(uploader.send(:original_filename))
     end
-    
+
     it "file names can be renamed when loading from remote urls" do
       uploader.class_eval do
         def filename
@@ -87,17 +87,17 @@ describe 'Storing Files', type: :feature do
       uploader.store!
       uploader.retrieve_from_store!(uploader.filename)
     end
-    
+
   end
-  
+
   context "secured storage" do
-    
+
     before(:each) do
       uploader.gcloud_bucket_is_public = false
       uploader.store!(image)
       uploader.retrieve_from_store!('image.png')
     end
-    
+
     it 'uploads the file to the configured bucket' do
       expect(uploader.file.size).to eq(image.size)
       expect(uploader.file.read).to eq(image.read)
@@ -128,20 +128,20 @@ describe 'Storing Files', type: :feature do
 
       image.close
     end
-    
+
     it 'gets an authenticated url for remote file' do
       uri = URI(uploader.url)
-      
+
       expect(uri.query_params).to include('Signature')
       expect(uri.query_params).to include('Expires')
       expect(uri.query_params).to include('GoogleAccessId')
 
       expect(uploader.file.read).to eq(image.read)
-      
+
       image.close
       uploader.file.delete
     end
-  
+
   end
-  
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,20 +9,19 @@ FeatureUploader = Class.new(CarrierWave::Uploader::Base) do
 end
 
 def source_environment_file!
-  
   if File.exists?('.env')
     File.readlines('.env').each do |line|
       key, value = line.split('=')
       ENV[key] = value.chomp
     end
   end
-  
-  ENV['GCLOUD_KEYFILE'] = Dir.pwd + "/.gcp-keyfile.json"
+
+  ENV['GCLOUD_KEYFILE'] = Dir.pwd + '/.gcp-keyfile.json'
 end
 
-RSpec.configure do |config|  
+RSpec.configure do |config|
   source_environment_file!
-  
+
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
   end
@@ -30,10 +29,7 @@ RSpec.configure do |config|
   # config.filter_run :focus
   config.run_all_when_everything_filtered = true
   config.order = :random
-
-  if config.files_to_run.one?
-    config.default_formatter = 'doc'
-  end
+  config.default_formatter = 'doc' if config.files_to_run.one?
 
   Kernel.srand config.seed
 
@@ -44,16 +40,16 @@ RSpec.configure do |config|
       config.gcloud_bucket_is_public             = true
       config.gcloud_authenticated_url_expiration = 600
       config.store_dir                           = 'uploaded_files'
-      
+
       config.gcloud_attributes = {
         expires: 600
       }
-      
+
       config.gcloud_credentials = {
         gcloud_project: ENV['GCLOUD_PROJECT'],
         gcloud_keyfile: ENV['GCLOUD_KEYFILE']
       }
     end
   end
-  
+
 end


### PR DESCRIPTION
This PR reworks several features:

- removes expensive api requests to google cloud
- makes `uploader.gcloud_credentials` optional because of `Google::Cloud` searches Project ID and Credentials JSON in environment variables. You can find more info [in official docs](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-storage/v1.9.0/guides/authentication)
- removes `by_verifying_existence` because Google::Cloud eating up the exception silently and simply returns nil
- bucket now initialized once per file at first request
- updates `google-cloud-storage` gem to 1.9.0
- updates `carrierwave` gem to 1.4.0
- bunch of refactoring with rubocop