### PR TITLE
Update google-cloud-storage dependency.

### DIFF
--- a/carrierwave-google-storage.gemspec
+++ b/carrierwave-google-storage.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'carrierwave', '~> 1.2.0'
-  spec.add_dependency 'google-cloud-storage', '~> 1.9.0'
+  spec.add_dependency 'google-cloud-storage', '~> 1.10'
   if RUBY_VERSION >= '2.2.2'
     spec.add_dependency 'activemodel', '>= 3.2.0'
   else


### PR DESCRIPTION
The version 1.10 of `google-cloud-storage` gem is now released. So, I've updated dependency to this gem.