### PR TITLE
Fix: destroying a uploader whose file doesn't exist will cause problem

### DIFF
--- a/lib/carrierwave/storage/gcloud_file.rb
+++ b/lib/carrierwave/storage/gcloud_file.rb
@@ -32,7 +32,7 @@ module CarrierWave
       end
 
       def delete
-        deleted = file.delete
+        deleted = file ? file.delete : true
         @file = nil if deleted
         deleted
       end


### PR DESCRIPTION
I ran into this issue when trying to destroy a fake model:

![image](https://user-images.githubusercontent.com/4011729/43088410-a6719fb4-8ed4-11e8-84bf-22f875cf2909.png)
