### PR TITLE
allow_nil on delegation when remote file does not exist

### DIFF
--- a/lib/carrierwave/storage/gcloud_file.rb
+++ b/lib/carrierwave/storage/gcloud_file.rb
@@ -8,7 +8,7 @@ module CarrierWave
       attr_writer :file
       attr_accessor :uploader, :connection, :path, :gcloud_options, :file_exists
 
-      delegate :content_disposition, :content_type, :size, to: :file
+      delegate :content_disposition, :content_type, :size, to: :file, allow_nil: true
 
       def initialize(uploader, connection, path)
         @uploader   = uploader


### PR DESCRIPTION
The delegated methods fail when the remote file is no longer present in the Google Storage.  