### PR TITLE
Fix multi bucket setups using same credentials

### DIFF
--- a/lib/carrierwave/storage/gcloud.rb
+++ b/lib/carrierwave/storage/gcloud.rb
@@ -42,7 +42,7 @@ module CarrierWave
           conn_cache[credentials] ||= ::Google::Cloud.new(
             credentials[:gcloud_project] || ENV['GCLOUD_PROJECT'],
             credentials[:gcloud_keyfile] || ENV['GCLOUD_KEYFILE']
-          ).storage.bucket(uploader.gcloud_bucket, skip_lookup: true)
+          ).storage
         end
       end
 

--- a/lib/carrierwave/storage/gcloud_file.rb
+++ b/lib/carrierwave/storage/gcloud_file.rb
@@ -92,7 +92,7 @@ module CarrierWave
       private
 
       def bucket
-        connection
+        @bucket ||= connection.bucket(uploader.gcloud_bucket, skip_lookup: true)
       end
     end
   end

--- a/spec/carrierwave/storage/gcloud_file_spec.rb
+++ b/spec/carrierwave/storage/gcloud_file_spec.rb
@@ -35,4 +35,10 @@ describe CarrierWave::Storage::GcloudFile do
     end
   end
 
+  describe '#bucket' do
+    it 'returns the internal bucket instance' do
+      expect(gcloud_file.send :bucket).to be(bucket)
+    end
+  end
+
 end


### PR DESCRIPTION
Currently, multi bucket setups as described in #25 and in the [carrierwave wiki](https://github.com/carrierwaveuploader/carrierwave/wiki/How-to:-Define-different-storage-configuration-for-each-Uploader.) are broken. This is because the connection cache does not only cache the storage connection, but the whole bucket for the first uploader that gets called.

If you have 2 uploaders with 2 different buckets, but using the same credentials, only one of them will work correctly. This PR fixes the issue by only caching the storage connection on the Gcloud class level, while buckets are cached on the GcloudFile instance level.