### PR TITLE
Fix rate limiting exceptions thrown by Google

### DIFF
--- a/spec/features/storing_files_spec.rb
+++ b/spec/features/storing_files_spec.rb
@@ -7,6 +7,7 @@ describe 'Storing Files', type: :feature do
 
   context 'common cases' do
     before(:each) do
+      sleep 1 # Prevent Google::Cloud::ResourceExhaustedError: rateLimitExceeded
       uploader.store!(image)
       uploader.retrieve_from_store!('image1.png')
     end


### PR DESCRIPTION
While this makes running specs slower, it will fix rate limiting
exceptions thrown by the Google Storage service. Apparently, you can
only manipulate an object once per second. On fast machines and/or
connections, this leads to this error while running specs:

```
Failures:

  1) Storing Files common cases returns url even if its not available
     Failure/Error:
       bucket_file = bucket.create_file(
         new_file.path,
         path,
         content_type: new_file.content_type,
         content_disposition: uploader.gcloud_content_disposition
       )

     Google::Cloud::ResourceExhaustedError:
       rateLimitExceeded: The total number of changes to the object carrierwave-g-storage/uploaded_files/image1.png exceeds the rate limit. Please reduce the rate of create, update, and delete requests.
     # ./lib/carrierwave/storage/gcloud_file.rb:62:in `store'
     # ./lib/carrierwave/storage/gcloud.rb:16:in `block in store!'
     # ./lib/carrierwave/storage/gcloud.rb:15:in `tap'
     # ./lib/carrierwave/storage/gcloud.rb:15:in `store!'
     # ./spec/features/storing_files_spec.rb:10:in `block (3 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Google::Apis::RateLimitError:
     #   rateLimitExceeded: The total number of changes to the object carrierwave-g-storage/uploaded_files/image1.png exceeds the rate limit. Please reduce the rate of create, update, and delete requests.
     #   ./lib/carrierwave/storage/gcloud_file.rb:62:in `store'
```

I saw the above error in about every second spec run. This PR definitely
fixes the issue, but I don't know if there is a better way to get around
the rate limiting. Maybe catch the `Google::Cloud::ResourceExhaustedError`
and try again after 1 second? If you prefer this way, let me know, I'm
happy to provide a PR.