### PR TITLE
Added option allow_nil to delegate methods

### DIFF
--- a/lib/carrierwave/storage/gcloud_file.rb
+++ b/lib/carrierwave/storage/gcloud_file.rb
@@ -8,7 +8,8 @@ module CarrierWave
       attr_writer :file
       attr_accessor :uploader, :connection, :path, :gcloud_options, :file_exists
 
-      delegate :content_disposition, :content_type, :size, to: :file
+      delegate :content_disposition, :content_type, :size, to: :file,
+        allow_nil: true
 
       def initialize(uploader, connection, path)
         @uploader   = uploader

--- a/spec/carrierwave/storage/gcloud_file_spec.rb
+++ b/spec/carrierwave/storage/gcloud_file_spec.rb
@@ -34,5 +34,4 @@ describe CarrierWave::Storage::GcloudFile do
       expect(gcloud_file.extension).to be_nil
     end
   end
-
 end


### PR DESCRIPTION
When file exists on database but there is on storage, occur the following exception error: `CarrierWave::Storage::GcloudFile#content_type delegated to file.content_type, but file is nil`