### PR TITLE
Added options as params on authenticated_url method.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ rvm:
   - 2.2.0
   - 2.3.0
   - 2.4.1
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1
+
 before_install:
   - openssl aes-256-cbc -k "$password" -in .gcp-keyfile.json.enc -out .gcp-keyfile.json -d
   - gem install bundler -v 1.12.1

--- a/lib/carrierwave/storage/gcloud_file.rb
+++ b/lib/carrierwave/storage/gcloud_file.rb
@@ -74,7 +74,7 @@ module CarrierWave
       end
 
       def url(options = {})
-        uploader.gcloud_bucket_is_public ? public_url : authenticated_url
+        uploader.gcloud_bucket_is_public ? public_url : authenticated_url(options)
       end
 
       def authenticated_url(options = {})

--- a/spec/carrierwave/storage/gcloud_file_spec.rb
+++ b/spec/carrierwave/storage/gcloud_file_spec.rb
@@ -41,4 +41,27 @@ describe CarrierWave::Storage::GcloudFile do
     end
   end
 
+  describe '#url' do
+    let(:options) { {} }
+
+    context 'when gcloud_bucket_is_public is false' do
+      before { allow(uploader).to receive(:gcloud_bucket_is_public).and_return(false) }
+
+      it 'calls public_url method' do
+        expect(gcloud_file).to receive(:authenticated_url).with(options)
+
+        gcloud_file.url(options)
+      end
+    end
+
+    context 'when gcloud_bucket_is_public is true' do
+      before { allow(uploader).to receive(:gcloud_bucket_is_public).and_return(true) }
+
+      it 'calls public_url method' do
+        expect(gcloud_file).to receive(:public_url)
+
+        gcloud_file.url
+      end
+    end
+  end
 end


### PR DESCRIPTION
When bucket is not public, autheticated_url method is called without options that is params, but it is necessary when this params not is nil when method url is called.