### PR TITLE
Support Ruby 3

### DIFF
--- a/carrierwave-google-storage.gemspec
+++ b/carrierwave-google-storage.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'carrierwave', ['>= 1.3.2', '< 4']
-  spec.add_dependency 'google-cloud-storage', '~> 1.18'
+  spec.add_dependency 'google-cloud-storage', '~> 1'
 
   if RUBY_VERSION >= '2.2.2'
     spec.add_dependency 'activemodel', '>= 3.2.0'


### PR DESCRIPTION
Currently, I'm upgrading my Ruby from version 2.7 to 3.3, and I'm encountering the error `ArgumentError (wrong number of arguments (given 4, expected 2..3))` when uploading and fetching a file. This issue is similar to a previous one documented at https://github.com/carrierwaveuploader/carrierwave-google-storage/issues/52.

It turns out that the `google-cloud-storage` dependency used in this project is currently at version `~> 1.18`, which means it is specified as `>= 1.18` and `< 1.19`.

The latest version of `google-cloud-storage` has already addressed this issue, and I have personally tested it for my application using a patch that doesn't restrict `google-cloud-storage` to the `1.18` minor version.

This pull request is intended to fix the mentioned issue. When I execute `bundle update`, I am not getting a version that works seamlessly with Ruby 3.