### PR TITLE
upgrade uri module based on carrierwave 3

### DIFF
--- a/lib/carrierwave/utilities/uri.rb
+++ b/lib/carrierwave/utilities/uri.rb
@@ -3,20 +3,23 @@ require 'uri'
 module CarrierWave
   module Utilities
     module Uri
-    # based on Ruby < 2.0's URI.encode
-    SAFE_STRING = URI::REGEXP::PATTERN::UNRESERVED + '\/'
-    UNSAFE = Regexp.new("[^#{SAFE_STRING}]", false)
+      # based on Ruby < 2.0's URI.encode
+      PATH_SAFE = URI::REGEXP::PATTERN::UNRESERVED + '\/'
+      PATH_UNSAFE = Regexp.new("[^#{PATH_SAFE}]", false)
+      NON_ASCII = /[^[:ascii:]]/.freeze
 
     private
+
       def encode_path(path)
-        path.to_s.gsub(UNSAFE) do
-          us = $&
-          tmp = ''
-          us.each_byte do |uc|
-            tmp << sprintf('%%%02X', uc)
-          end
-          tmp
-        end
+        URI::DEFAULT_PARSER.escape(path, PATH_UNSAFE)
+      end
+
+      def encode_non_ascii(str)
+        URI::DEFAULT_PARSER.escape(str, NON_ASCII)
+      end
+
+      def decode_uri(str)
+        URI::DEFAULT_PARSER.unescape(str)
       end
     end # Uri
   end # Utilities


### PR DESCRIPTION
Uri module was not compatible with carrierwave 3: I checked it was just a copy of carrierwave 2 uri module, so I take it from carrierwave 3